### PR TITLE
Update default.rb

### DIFF
--- a/infra/cookbooks/postgresql/attributes/default.rb
+++ b/infra/cookbooks/postgresql/attributes/default.rb
@@ -73,8 +73,8 @@ end
 
 # Host Based Access
 default[:postgresql][:hba] = [
-  { :method => 'md5', :address => '127.0.0.1/32' },
-  { :method => 'md5', :address => '::1/128' }
+  { :method => 'sha256', :address => '127.0.0.1/32' },
+  { :method => 'sha256', :address => '::1/128' }
 ]
 
 # Replication/Hot Standby (set to postgresql defaults)


### PR DESCRIPTION
MD5 has security weaknesses, better to use SHA256 instead. This pull request addresses issue `https://github.com/ChrisAntaki/victorykit/issues/1`. Any feedback is appreciatted. 